### PR TITLE
Fix hardcoded repo URL in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Every change — feature, fix, refactor, docs, or skill — follows this process
 
 ### 1. File a GitHub issue
 
-Use the [feature request template](https://github.com/stvhay/summarizer/issues/new?template=feature-request.yml) to describe the problem and proposed solution. Small fixes can reference an existing issue.
+File a GitHub issue describing the problem and proposed solution. Use the feature request or bug report template. Small fixes can reference an existing issue.
 
 ### 2. Create a branch
 


### PR DESCRIPTION
## Summary
- Replaces hardcoded `stvhay/summarizer` issue template link with descriptive text
- GitHub relative links only work for repo files, not web routes like `/issues/new`, so descriptive text is the only portable option
- Fixes #3

## Test plan
- [x] Verify CONTRIBUTING.md renders correctly on GitHub
- [x] Confirm no other hardcoded repo URLs remain in CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)