### PR TITLE
Add PR-aware review flow with authorship detection

### DIFF
--- a/.claude/skills/requesting-code-review/SKILL.md
+++ b/.claude/skills/requesting-code-review/SKILL.md
@@ -28,7 +28,9 @@ Dispatch code-reviewer subagent to catch issues before they cascade.
 Determine if a PR exists for the current branch and whether you are the author:
 
 ```bash
-# Get PR number and author in a single API call
+# Get PR number and author in a single API call.
+# NOTE: If this fails, check gh auth status before assuming no PR exists.
+# See "Error handling" below — silent fallback masks auth/network failures.
 PR_JSON=$(gh pr view --json number,author 2>/dev/null) || PR_JSON=""
 
 if [ -n "$PR_JSON" ]; then
@@ -58,7 +60,7 @@ Use Task tool with code-reviewer type, fill template at `code-reviewer.md`
 
 **Placeholders:**
 - `{WHAT_WAS_IMPLEMENTED}` - What you just built
-- `{PLAN_OR_REQUIREMENTS}` - What it should do
+- `{PLAN_REFERENCE}` - What it should do
 - `{BASE_SHA}` - Starting commit
 - `{HEAD_SHA}` - Ending commit
 - `{DESCRIPTION}` - Brief summary
@@ -84,7 +86,7 @@ HEAD_SHA=9a0d42a
 
 [Dispatch code-reviewer subagent]:
   WHAT_WAS_IMPLEMENTED: PR-aware review flow with authorship detection
-  PLAN_OR_REQUIREMENTS: Task 2 from docs/plans/optimize-pr-review.md
+  PLAN_REFERENCE: Task 2 from docs/plans/optimize-pr-review.md
   BASE_SHA: 447c459
   HEAD_SHA: 9a0d42a
   DESCRIPTION: Added context detection, PR commenting, and authorship-based action branching

--- a/.claude/skills/requesting-code-review/SKILL.md
+++ b/.claude/skills/requesting-code-review/SKILL.md
@@ -23,13 +23,31 @@ Dispatch code-reviewer subagent to catch issues before they cascade.
 
 ## How to Request
 
-**1. Get git SHAs:**
+**1. Detect context:**
+
+Determine if a PR exists for the current branch and whether you are the author:
+
+```bash
+# Get PR number (empty if no PR exists)
+PR_NUMBER=$(gh pr view --json number --jq '.number' 2>/dev/null || echo "")
+
+# If PR exists, check authorship
+if [ -n "$PR_NUMBER" ]; then
+  PR_AUTHOR=$(gh pr view --json author --jq '.author.login')
+  CURRENT_USER=$(gh api user --jq '.login')
+  IS_AUTHOR=$( [ "$PR_AUTHOR" = "$CURRENT_USER" ] && echo "true" || echo "false" )
+fi
+```
+
+If no PR exists, the review runs locally only (existing behavior).
+
+**2. Get git SHAs:**
 ```bash
 BASE_SHA=$(git rev-parse HEAD~1)  # or origin/main
 HEAD_SHA=$(git rev-parse HEAD)
 ```
 
-**2. Dispatch code-reviewer subagent:**
+**3. Dispatch code-reviewer subagent:**
 
 Use Task tool with code-reviewer type, fill template at `code-reviewer.md`
 
@@ -39,39 +57,56 @@ Use Task tool with code-reviewer type, fill template at `code-reviewer.md`
 - `{BASE_SHA}` - Starting commit
 - `{HEAD_SHA}` - Ending commit
 - `{DESCRIPTION}` - Brief summary
+- `{PR_NUMBER}` - PR number (empty for local-only review)
+- `{IS_AUTHOR}` - `true` if current user authored the PR, `false` otherwise
 
-**3. Act on feedback:**
+**4. Act on feedback:**
 - Fix Critical issues immediately
 - Fix Important issues before proceeding
 - Note Minor issues for later
 - Push back if reviewer is wrong (with reasoning)
 
-## Example
+## Example: Local Review (no PR)
 
 ```
 [Just completed Task 2: Add verification function]
 
 You: Let me request code review before proceeding.
 
+PR_NUMBER=""  # No PR exists yet
 BASE_SHA=$(git log --oneline | grep "Task 1" | head -1 | awk '{print $1}')
 HEAD_SHA=$(git rev-parse HEAD)
 
+[Dispatch code-reviewer subagent with PR_NUMBER="" IS_AUTHOR=""]
+
+[Subagent returns review locally]
+You: [Fix issues, continue to Task 3]
+```
+
+## Example: PR Review (self-authored)
+
+```
+[PR #5 is open, you are the author]
+
+PR_NUMBER=5, IS_AUTHOR=true
+
 [Dispatch code-reviewer subagent]
-  WHAT_WAS_IMPLEMENTED: Verification and repair functions for conversation index
-  PLAN_OR_REQUIREMENTS: Task 2 from docs/plans/deployment-plan.md
-  BASE_SHA: a7981ec
-  HEAD_SHA: 3df7661
-  DESCRIPTION: Added verifyIndex() and repairIndex() with 4 issue types
+[Subagent posts structured comment on PR #5]
+[Clean review: comment signals LGTM — no --approve attempted]
+[Issues found: comment lists them — no --request-changes attempted]
+```
 
-[Subagent returns]:
-  Strengths: Clean architecture, real tests
-  Issues:
-    Important: Missing progress indicators
-    Minor: Magic number (100) for reporting interval
-  Assessment: Ready to proceed
+## Example: PR Review (external)
 
-You: [Fix progress indicators]
-[Continue to Task 3]
+```
+[PR #12 from a contributor, you are not the author]
+
+PR_NUMBER=12, IS_AUTHOR=false
+
+[Dispatch code-reviewer subagent]
+[Subagent posts structured comment on PR #12]
+[Clean review: gh pr review 12 --approve]
+[Issues found: gh pr review 12 --request-changes]
 ```
 
 ## Integration with Workflows

--- a/.claude/skills/requesting-code-review/SKILL.md
+++ b/.claude/skills/requesting-code-review/SKILL.md
@@ -28,18 +28,23 @@ Dispatch code-reviewer subagent to catch issues before they cascade.
 Determine if a PR exists for the current branch and whether you are the author:
 
 ```bash
-# Get PR number (empty if no PR exists)
-PR_NUMBER=$(gh pr view --json number --jq '.number' 2>/dev/null || echo "")
+# Get PR number and author in a single API call
+PR_JSON=$(gh pr view --json number,author 2>/dev/null) || PR_JSON=""
 
-# If PR exists, check authorship
-if [ -n "$PR_NUMBER" ]; then
-  PR_AUTHOR=$(gh pr view --json author --jq '.author.login')
+if [ -n "$PR_JSON" ]; then
+  PR_NUMBER=$(echo "$PR_JSON" | jq -r '.number')
+  PR_AUTHOR=$(echo "$PR_JSON" | jq -r '.author.login')
   CURRENT_USER=$(gh api user --jq '.login')
   IS_AUTHOR=$( [ "$PR_AUTHOR" = "$CURRENT_USER" ] && echo "true" || echo "false" )
+else
+  PR_NUMBER=""
+  IS_AUTHOR=""
 fi
 ```
 
 If no PR exists, the review runs locally only (existing behavior).
+
+**Error handling:** If `gh pr view` fails for reasons other than "no PR" (auth failure, network error, rate limit), the agent must surface the error rather than silently falling back to local-only review. Check `gh auth status` and retry before assuming no PR exists. A silent fallback means the agent skips posting to the PR — the user won't know the review happened.
 
 **2. Get git SHAs:**
 ```bash
@@ -69,18 +74,31 @@ Use Task tool with code-reviewer type, fill template at `code-reviewer.md`
 ## Example: Local Review (no PR)
 
 ```
-[Just completed Task 2: Add verification function]
+[Just completed Task 2: Add PR-aware review flow]
 
 You: Let me request code review before proceeding.
 
 PR_NUMBER=""  # No PR exists yet
-BASE_SHA=$(git log --oneline | grep "Task 1" | head -1 | awk '{print $1}')
-HEAD_SHA=$(git rev-parse HEAD)
+BASE_SHA=447c459
+HEAD_SHA=9a0d42a
 
-[Dispatch code-reviewer subagent with PR_NUMBER="" IS_AUTHOR=""]
+[Dispatch code-reviewer subagent]:
+  WHAT_WAS_IMPLEMENTED: PR-aware review flow with authorship detection
+  PLAN_OR_REQUIREMENTS: Task 2 from docs/plans/optimize-pr-review.md
+  BASE_SHA: 447c459
+  HEAD_SHA: 9a0d42a
+  DESCRIPTION: Added context detection, PR commenting, and authorship-based action branching
+  PR_NUMBER: ""
+  IS_AUTHOR: ""
 
-[Subagent returns review locally]
-You: [Fix issues, continue to Task 3]
+[Subagent returns]:
+  Strengths: Clean decision matrix, backwards-compatible design
+  Issues:
+    Important: Redundant API calls in detection script
+    Minor: Examples lack concrete placeholder values
+  Assessment: Ready to proceed with fixes
+
+You: [Fix redundant API calls, continue to Task 3]
 ```
 
 ## Example: PR Review (self-authored)

--- a/.claude/skills/requesting-code-review/code-reviewer.md
+++ b/.claude/skills/requesting-code-review/code-reviewer.md
@@ -4,7 +4,7 @@ You are reviewing code changes for production readiness.
 
 **Your task:**
 1. Review {WHAT_WAS_IMPLEMENTED}
-2. Compare against {PLAN_OR_REQUIREMENTS}
+2. Compare against {PLAN_REFERENCE}
 3. Check code quality, architecture, testing
 4. Categorize issues by severity
 5. Assess production readiness

--- a/.claude/skills/requesting-code-review/code-reviewer.md
+++ b/.claude/skills/requesting-code-review/code-reviewer.md
@@ -21,7 +21,7 @@ You are reviewing code changes for production readiness.
 ## PR Context
 
 **PR Number:** {PR_NUMBER} (empty if local-only review)
-**Author is reviewer:** {IS_AUTHOR} (`true`/`false`, empty if local-only)
+**Self-authored PR:** {IS_AUTHOR} (`true`/`false`, empty if local-only)
 
 ## Git Range to Review
 

--- a/.claude/skills/requesting-code-review/code-reviewer.md
+++ b/.claude/skills/requesting-code-review/code-reviewer.md
@@ -8,6 +8,7 @@ You are reviewing code changes for production readiness.
 3. Check code quality, architecture, testing
 4. Categorize issues by severity
 5. Assess production readiness
+6. If reviewing a PR, post findings and take the appropriate final action
 
 ## What Was Implemented
 
@@ -16,6 +17,11 @@ You are reviewing code changes for production readiness.
 ## Requirements/Plan
 
 {PLAN_REFERENCE}
+
+## PR Context
+
+**PR Number:** {PR_NUMBER} (empty if local-only review)
+**Author is reviewer:** {IS_AUTHOR} (`true`/`false`, empty if local-only)
 
 ## Git Range to Review
 
@@ -106,6 +112,29 @@ git diff {BASE_SHA}..{HEAD_SHA}
 - Give feedback on code you didn't review
 - Be vague ("improve error handling")
 - Avoid giving a clear verdict
+
+## Post to PR
+
+If `{PR_NUMBER}` is set, post findings to the PR after completing the review.
+
+**1. Post the review as a PR comment:**
+
+Format the full review output (Strengths, Issues, Recommendations, Assessment) as markdown and post:
+
+```bash
+gh pr comment {PR_NUMBER} --body "<review markdown>"
+```
+
+**2. Take the appropriate final action based on authorship and outcome:**
+
+| IS_AUTHOR | Assessment | Action |
+|---|---|---|
+| `true` | Ready to merge | Comment only (GitHub blocks self-approval) |
+| `true` | Has issues | Comment only (GitHub blocks self-request-changes) |
+| `false` | Ready to merge | `gh pr review {PR_NUMBER} --approve --body "LGTM — <one-line summary>"` |
+| `false` | Has issues | `gh pr review {PR_NUMBER} --request-changes --body "<one-line summary>"` |
+
+If `{PR_NUMBER}` is empty, return the review locally only (existing behavior).
 
 ## Example Output
 


### PR DESCRIPTION
## Summary

- `/requesting-code-review` now detects PR context and authorship before dispatching the review subagent
- Review findings are posted as structured PR comments via `gh pr comment`
- Final action branches: self-authored PRs get comments only; external PRs get approval or request-changes

## Issue

Closes #5

## Implementation plan

<details>
<summary>Plan</summary>

# Plan: Optimize PR Review Skill for Self-Authored and External PRs

**Issue:** #5
**Date:** 2026-03-02

## Problem

`/requesting-code-review` runs a local subagent but doesn't interact with the GitHub PR — no comments, no approvals. Self-authored PRs can't be approved due to a GitHub platform restriction.

## Design

The review analysis is identical regardless of authorship. Only the final GitHub action differs:

| Scenario | Clean | Issues |
|---|---|---|
| Self-authored | Comment (LGTM) | Comment (issues) |
| External PR | Comment + approve | Comment + request-changes |

## Tasks

### Task 1: Update SKILL.md to add PR-aware review flow

**Files:** `.claude/skills/requesting-code-review/SKILL.md`

Add authorship detection step, PR_NUMBER and IS_AUTHOR placeholders, and three examples (local, self-authored PR, external PR).

### Task 2: Update code-reviewer.md template to support PR output

**Files:** `.claude/skills/requesting-code-review/code-reviewer.md`

Add PR Context section with placeholders, "Post to PR" section with authorship-based action table, and instructions for posting findings as PR comments.

## Out of Scope

- GitHub App or bot account for self-approval (separate concern)
- Branch protection rule changes (separate concern)
- Changes to `/receiving-code-review` skill

</details>

## Checklist

- [x] Linked to a GitHub issue
- [x] Implementation plan included above
- [x] Atomic commits (one logical change per commit)
- [ ] `/verification-before-completion` — all claims verified with evidence
- [ ] `/requesting-code-review` — self-reviewed before submitting

## Skills used

- [x] `/brainstorming-design`
- [x] `/writing-plans`
- [x] `/executing-plans`
- [ ] `/verification-before-completion` (auto-triggered)
- [ ] `/requesting-code-review`
- [ ] `/finishing-a-development-branch` (auto-triggered)
- [ ] `/using-git-worktrees`
- [ ] `/systematic-debugging`
- [ ] `/writing-skills` (for skill contributions)
- [ ] `/writing-clearly-and-concisely`

🤖 Generated with [Claude Code](https://claude.com/claude-code)